### PR TITLE
ical, bundle improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Only include the leaflet bundle where it is needed via ``add_bundle_on_request``.
+  [thet]
+
 - Adapt the ``contenttype-venue`` icon to recent changes in plonetheme.barceloneta 1.7.4.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
+- Add ``IICalendarEventComponent`` adapter to customize the ical export of ``location``, ``contact`` and ``geo`` properties.
+
+
 - Only include the leaflet bundle where it is needed via ``add_bundle_on_request``.
   [thet]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Add ``IICalendarEventComponent`` adapter to customize the ical export of ``location``, ``contact`` and ``geo`` properties.
+- Prevent ``ILocation`` behavior not adaptable in ``VenueEventAccessor``.
+  [thet]
 
+- Add ``IICalendarEventComponent`` adapter to customize the ical export of ``location``, ``contact`` and ``geo`` properties.
+  [thet]
 
 - Only include the leaflet bundle where it is needed via ``add_bundle_on_request``.
   [thet]

--- a/collective/venue/behaviors.py
+++ b/collective/venue/behaviors.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from collective.venue import messageFactory as _
+from collective.venue.interfaces import IVenueEnabled
 from collective.venue.utils import get_base_path
 from plone import api
 from plone.app.z3cform.widget import RelatedItemsFieldWidget
@@ -8,6 +9,7 @@ from plone.autoform.interfaces import IFormFieldProvider
 from plone.supermodel import directives
 from plone.supermodel import model
 from zope import schema
+from zope.component import adapter
 from zope.interface import provider
 from zope.schema.interfaces import IContextAwareDefaultFactory
 
@@ -21,7 +23,7 @@ def default_location(context):
 
 
 @provider(IFormFieldProvider)
-class ILocation(model.Schema):
+class ILocation(model.Schema, IVenueEnabled):
 
     location_uid = schema.Choice(
         title=_(u'label_event_location', default=u'Location'),
@@ -70,7 +72,7 @@ def default_organizer(context):
 
 
 @provider(IFormFieldProvider)
-class IOrganizer(model.Schema):
+class IOrganizer(model.Schema, IVenueEnabled):
 
     organizer_uid = schema.Choice(
         title=_(u'label_event_organizer', default=u'Organizer'),

--- a/collective/venue/browser/venue.py
+++ b/collective/venue/browser/venue.py
@@ -7,6 +7,8 @@ from collective.venue import messageFactory as _
 from plone.api.portal import get_registry_record as getrec
 from plone.app.uuid.utils import uuidToObject
 from plone.uuid.interfaces import IUUID
+from Products.CMFPlone.resources import add_bundle_on_request
+from Products.CMFPlone.utils import get_top_request
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 
@@ -35,6 +37,11 @@ class VenueView(BrowserView):
                 # subsite on any context. However, this might lead to broken
                 # urls in for the edit bar.
                 context = venue_obj
+
+        top_request = get_top_request(request)
+        # Just add the bundle from plone.patternslib.
+        # If it's not available, it wont't hurt.
+        add_bundle_on_request(top_request, 'bundle-leaflet')
 
         self.context = context
         self.request = request

--- a/collective/venue/configure.zcml
+++ b/collective/venue/configure.zcml
@@ -9,6 +9,7 @@
   <i18n:registerTranslations directory="locales" />
 
   <includeDependencies package="." />
+  <include package="plone.app.event"/>
   <include package="collective.address"/>
   <include package="collective.geolocationbehavior" zcml:condition="installed collective.geolocationbehavior"/>
 
@@ -31,6 +32,14 @@
       name="venue.organizerreference"
       title="collective.venue event organizer"
       provides=".behaviors.IOrganizer"
+      />
+
+  <class class="plone.app.event.recurrence.Occurrence">
+    <implements interface=".interfaces.IVenueEnabled" />
+  </class>
+  <adapter
+      for=".interfaces.IVenueEnabled"
+      factory=".icalexporter.AAFICalendarEventComponent"
       />
 
   <adapter name="SearchableText" factory=".indexer.searchable_text_indexer"/>

--- a/collective/venue/eventaccessor.py
+++ b/collective/venue/eventaccessor.py
@@ -29,7 +29,9 @@ class VenueEventAccessor(EventAccessor):
     @property
     def location(self):
         context = self.context
-        location_ref = ILocation(context)
+        location_ref = ILocation(context, None)
+        if not location_ref:
+            return
         location_uid = location_ref.location_uid
         location_notes = location_ref.location_notes
         location = uuidToObject(location_uid)

--- a/collective/venue/eventaccessor.py
+++ b/collective/venue/eventaccessor.py
@@ -32,12 +32,12 @@ class VenueEventAccessor(EventAccessor):
         location_ref = ILocation(context)
         location_uid = location_ref.location_uid
         location_notes = location_ref.location_notes
-        location_url = location_ref.location_url
         location = uuidToObject(location_uid)
 
         meta_basic = IBasic(location, None)
         add = IAddress(location, None)
 
+        location_url = None
         ret = u''
         if meta_basic and add:
             # I'm a location reference.

--- a/collective/venue/icalexporter.py
+++ b/collective/venue/icalexporter.py
@@ -1,0 +1,83 @@
+from collective.venue import utils
+from collective.venue.behaviors import ILocation
+from collective.venue.behaviors import IOrganizer
+from plone.app.dexterity.behaviors.metadata import IBasic
+from plone.app.event.ical.exporter import ICalendarEventComponent
+from plone.app.uuid.utils import uuidToObject
+from plone.event.interfaces import IICalendarEventComponent
+from zope.interface import implementer
+
+
+try:
+    from collective.geolocationbehavior.geolocation import IGeolocatable
+except ImportError:
+    IGeolocatable = None
+
+
+@implementer(IICalendarEventComponent)
+class AAFICalendarEventComponent(ICalendarEventComponent):
+    """Returns an icalendar object of the event.
+    """
+
+    @property
+    def location(self):
+        if not ILocation.providedBy(self.context):
+            return super(AAFICalendarEventComponent, self).location
+
+        ref = ILocation(self.context)
+        item = uuidToObject(ref.location_uid)
+
+        ret = None
+        if item:
+            basic = IBasic(item, None)
+            locationstring =  utils.join_nonempty([
+                basic.title,
+                utils.get_venue_address_string(item)
+            ], sep=u', ')
+            ret = {
+                'value': locationstring,
+                'parameters': {'altrep': item.absolute_url()}
+            }
+        else:
+            ret = {'value': ref.location_notes}
+
+        return ret
+
+    @property
+    def contact(self):
+        if not IOrganizer.providedBy(self.context):
+            return super(AAFICalendarEventComponent, self).organizer
+
+        ref = IOrganizer(self.context)
+        item = uuidToObject(ref.organizer_uid)
+
+        ret = None
+        if item:
+            basic = IBasic(item, None)
+            retstring =  utils.join_nonempty([
+                basic.title,
+                utils.get_venue_contact_string(item)
+            ], sep=u', ')
+            ret = {'value': retstring}
+        else:
+            ret = {'value': ref.organizer_notes}
+
+        return ret
+
+    @property
+    def geo(self):
+        if not ILocation.providedBy(self.context):
+            return super(AAFICalendarEventComponent, self).geo
+
+        ref = ILocation(self.context)
+        item = uuidToObject(ref.location_uid)
+
+        if not IGeolocatable.providedBy(item):
+            return super(AAFICalendarEventComponent, self).geo
+
+        geo = IGeolocatable(item, None)
+        ret = (
+            geo.geolocation.latitude,
+            geo.geolocation.longitude
+        )
+        return {'value': ret}

--- a/collective/venue/interfaces.py
+++ b/collective/venue/interfaces.py
@@ -145,3 +145,10 @@ class IVenueLayer(Interface):
     """A Browserlayer indicating that this product is actually installed via
     Generic Setup.
     """
+
+
+from plone.event.interfaces import IEvent
+class IVenueEnabled(IEvent):
+    """Marker interface for objects which provide the ILocation or IOrganizer
+    interfaces.
+    """

--- a/collective/venue/utils.py
+++ b/collective/venue/utils.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
+from collective.address.behaviors import IAddress
+from collective.address.behaviors import IContact
+from collective.address.vocabulary import get_pycountry_name
 from plone import api
-from zope.component.hooks import getSite
 from plone.app.uuid.utils import uuidToPhysicalPath
+from plone.uuid.interfaces import IUUID
+from zope.component.hooks import getSite
+
+
+try:
+    from collective.geolocationbehavior.geolocation import IGeolocatable
+except ImportError:
+    IGeolocatable = None
 
 
 def join_nonempty(items, sep=u'/'):
@@ -18,3 +28,51 @@ def get_base_path(context=None):
     if search_base:
         path = uuidToPhysicalPath(search_base)
     return path
+
+
+def get_venue_url(venue):
+    """Get URL to venue.
+    We explicitly support here venues defined in other subsites. If so, URL is
+    specially constructed, so that we can show the venue in our own site.
+    """
+    # construct url to location
+    site = getSite()
+    venue_url = venue.absolute_url()
+    site_path = u'/'.join(site.getPhysicalPath())
+    venue_path = u'/'.join(venue.getPhysicalPath())
+    if site_path not in venue_path:
+        # venue in different site - cannot directly open it
+        venue_url = u'{0}/@@venue_view?uid={1}'.format(
+            site.absolute_url(),
+            IUUID(venue)
+        )
+    return venue_url
+
+
+def get_venue_address_string(venue):
+    address = IAddress(venue, None)
+    if not address:
+        return
+
+    country = get_pycountry_name(address.country)
+    ret = join_nonempty((
+        address.street,
+        join_nonempty((address.zip_code, address.city), sep=u' '),
+        country
+    ), sep=u', ')
+
+    return ret
+
+
+def get_venue_contact_string(venue):
+    contact = IContact(venue, None)
+    if not contact:
+        return
+
+    ret = join_nonempty((
+        contact.email,
+        contact.website,
+        contact.phone or contact.mobile
+    ), sep=u', ')
+
+    return ret


### PR DESCRIPTION
- Prevent ``ILocation`` behavior not adaptable in ``VenueEventAccessor``.
- Add ``IICalendarEventComponent`` adapter to customize the ical export of ``location``, ``contact`` and ``geo`` properties.
- Only include the leaflet bundle where it is needed via ``add_bundle_on_request``.
