### PR TITLE
Remove version constraint of z3c.unconfigure.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,22 @@
 Changelog
 =========
 
-3.1.3 (unreleased)
-------------------
+4.0 (unreleased)
+----------------
 
-- Nothing changed yet.
+Breaking changes:
+
+    - Remove version constraint of z3c.unconfigure.
+      Since Plone 5.1 z3c.unconfigure is pinned to 1.1.
+      [arsenico13, thet]
+
+New features:
+
+    - add item here
+
+Bug fixes:
+
+    - add item here
 
 
 3.1.2 (2017-12-06)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = '3.1.3.dev0'
+version = '4.0.dev0'
 
 
 setup(
@@ -38,7 +38,7 @@ setup(
         'plone.resource',
         'Products.CMFPlone',
         'Products.GenericSetup',
-        'z3c.unconfigure < 1.1',
+        'z3c.unconfigure',
     ],
     extras_require={
         'geolocation': [


### PR DESCRIPTION
Since Plone 5.1 z3c.unconfigure is pinned to 1.1.
Fixes: #6 

Version bump to 4.0 since it's a breaking change.