### PR TITLE
Fix GenericSetup registry import on Plone 6.2 (IResourceRegistry/IBundleRegistry)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,13 @@ Changelog
 4.2 (unreleased)
 ----------------
 
+- Fix GenericSetup registry import on Plone 6.2: reference
+  ``plone.base.interfaces.IResourceRegistry`` / ``IBundleRegistry`` instead of
+  the deprecated ``Products.CMFPlone.interfaces`` aliases, which resolve to a
+  ``dict`` at runtime and break profile import with
+  ``AttributeError: 'dict' object has no attribute '__identifier__'``.
+  [jensens]
+
 - Updated the add-on documentation.
   [macagua]
 

--- a/collective/venue/profiles/base/registry.xml
+++ b/collective/venue/profiles/base/registry.xml
@@ -4,7 +4,7 @@
   <records interface="collective.venue.interfaces.IVenueSettings"
            prefix="collective.venue" />
 
-  <records prefix="plone.resources/collective-venue" interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+  <records prefix="plone.resources/collective-venue" interface='plone.base.interfaces.IResourceRegistry'>
     <value key="js">++plone++collective.venue/locationsearch.js</value>
     <value key="url">++plone++collective.venue</value>
     <value key="css">
@@ -12,14 +12,14 @@
     </value>
   </records>
 
-  <records prefix="plone.resources/collective-venue-bundle" interface='Products.CMFPlone.interfaces.IResourceRegistry'>
+  <records prefix="plone.resources/collective-venue-bundle" interface='plone.base.interfaces.IResourceRegistry'>
     <value key="js">++plone++collective.venue/collective-venue-bundle.js</value>
     <value key="css">
       <element>++plone++collective.venue/styles.less</element>
     </value>
   </records>
 
-  <records prefix="plone.bundles/collective-venue-bundle" interface='Products.CMFPlone.interfaces.IBundleRegistry'>
+  <records prefix="plone.bundles/collective-venue-bundle" interface='plone.base.interfaces.IBundleRegistry'>
     <value key="resources">
       <element>collective-venue-bundle</element>
     </value>

--- a/collective/venue/profiles/uninstall/registry.xml
+++ b/collective/venue/profiles/uninstall/registry.xml
@@ -2,7 +2,7 @@
 <registry>
 
   <records remove="True" interface="collective.venue.interfaces.IVenueSettings" prefix="collective.venue" />
-  <records remove="True" prefix="plone.resources/collective-venue" interface='Products.CMFPlone.interfaces.IResourceRegistry'/>
-  <records remove="True" prefix="plone.bundles/collective-venue-bundle" interface='Products.CMFPlone.interfaces.IBundleRegistry'/>
+  <records remove="True" prefix="plone.resources/collective-venue" interface='plone.base.interfaces.IResourceRegistry'/>
+  <records remove="True" prefix="plone.bundles/collective-venue-bundle" interface='plone.base.interfaces.IBundleRegistry'/>
 
 </registry>


### PR DESCRIPTION
## Problem

On Plone 6.2, `Products.CMFPlone.interfaces.IResourceRegistry` and `IBundleRegistry` are deprecated aliases (`zope.deferredimport`) that resolve to a plain `dict` at runtime in a fully started instance. GenericSetup's registry importer then fails on profile import:

```
AttributeError: 'dict' object has no attribute '__identifier__'
```

This breaks site creation / profile import whenever collective.venue's `base` profile runs.

## Fix

Reference the canonical interfaces from `plone.base.interfaces` instead, in both `profiles/base/registry.xml` and `profiles/uninstall/registry.xml`. (Other add-ons, e.g. collective.collectionfilter, already use the `plone.base.interfaces` path.)

Verified: an aaf.deployment Plone 6.2 site that previously failed at this exact records node now gets past the registry import step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)